### PR TITLE
[FIX] 영상 업로드 API 경로 및 request 수정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,5 @@ RUN cd /code && \
 # 애플리케이션 코드 복사
 COPY ./app /code/app
 
-# received_video와 received_audio 디렉토리 생성
-RUN mkdir -p /code/received_video /code/received_audio
-
 # 실행
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]

--- a/app/routers/upload_router.py
+++ b/app/routers/upload_router.py
@@ -1,38 +1,30 @@
 import os
 from typing import List
+import tempfile
 
-from fastapi import APIRouter, UploadFile, File, HTTPException, Request
+from fastapi import APIRouter, UploadFile, File, HTTPException, Request, Path
 
 router = APIRouter()
 
-SAVE_PATH = os.path.join(os.getcwd(), "received_video")
-
-@router.post("/analyze/videos")
-async def analyze_videos(request: Request):
-    body = await request.body()
-    print(f"요청 본문 크기: {len(body)} 바이트")
-
-    form = await request.form()
-    files: List[UploadFile] = []
-
-    # FormData에 포함된 모든 항목 중 UploadFile인 것만 추출
-    for key, value in form.items():
-        if isinstance(value, UploadFile):
-            files.append(value)
-
-    analysis_results = []
-
+@router.post("/interview/{interviewId}/video/analyze")
+async def analyze_videos(interviewId: int, files: List[UploadFile] = File(...)):
     for file in files:
-        # 영상 저장
-        file_path = os.path.join(SAVE_PATH, file.filename)
-        with open(file_path, "wb") as f:
+        # 고유한 temp 파일 경로 생성
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".mp4") as temp_file:
             content = await file.read()
-            f.write(content)
+            temp_file.write(content)
+            temp_path = temp_file.name
 
-        print(f"저장 완료: {file_path}")
-        # 분석 (여기서 MediaPipe 분석 함수 호출)
+        # 분석 함수 호출
 
-        # 저장 파일 삭제 (분석 후 삭제를 원할 경우 주석 해제)
-        # os.remove(file_path)
+        # 분석 후 삭제
+        os.remove(temp_path)
 
-    return {"results": analysis_results}
+    return {
+        "isSuccess": True,
+        "code": "COMMON200",
+        "message": "성공입니다.",
+        "result": {
+            "interviewId": interviewId
+        }
+    }


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 영상 업로드 경로 "/interview/{interviewId}/video/analyze"로 수정
- 받은 영상 tempFile로 저장
- 영상 리스트 files로 받기
- 영상이나 음성 파일은 tempFile로 저장하기 위해 Dockerfile 파일 저장 경로 생성하는 명령어 삭제
- received_audio, received_video 폴더 삭제

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 영상 업로드 경로 수정되었습니다.
- 영상 리스트는 files로 받습니다.

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #40 
