### PR TITLE
[FEAT] 세특 기반 해시태그, 유형, 유형설명 추가

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -57,4 +57,5 @@ jobs:
               -e CLOVA_OCR_URL="${{ secrets.CLOVA_OCR_URL }}" \
               -e CLOVA_OCR_SECRET_KEY="${{ secrets.CLOVA_OCR_SECRET_KEY }}" \
               -e JWT_SECRET_KEY="${{ secrets.JWT_SECRET_KEY }}" \
+              -e JWT_SECRET_KEY="${{ secrets.GPT_API_KEY }}" \
               --name ${{ env.CONTAINER_NAME }} ${{ env.DOCKER_IMAGE_NAME }}:latest

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -17,6 +17,7 @@ class Settings(BaseSettings):
     AWS_ACCESS_KEY: str
     AWS_SECRET_KEY: str
     S3_BUCKET_NAME: str
+    GPT_API_KEY: str
 
 
 settings = Settings()

--- a/app/models/document_model.py
+++ b/app/models/document_model.py
@@ -1,0 +1,12 @@
+from typing import Optional, List
+from pydantic import BaseModel
+
+
+class Document(BaseModel):
+    user_id: Optional[str] = None
+    content: Optional[str] = None
+    gradle: Optional[dict] = None
+    features: Optional[str] = None
+    type: Optional[str] = None
+    hashtags: Optional[List[str]] = None
+    explanation: Optional[str] = None

--- a/app/models/document_model.py
+++ b/app/models/document_model.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel
 class Document(BaseModel):
     user_id: Optional[str] = None
     content: Optional[str] = None
-    gradle: Optional[dict] = None
+    grades: Optional[dict] = None
     features: Optional[str] = None
     type: Optional[str] = None
     hashtags: Optional[List[str]] = None

--- a/app/repository/document_repository.py
+++ b/app/repository/document_repository.py
@@ -1,10 +1,18 @@
 from app.core.database import database
+from app.models.document_model import Document
 
-collection = database['documents']
+document_collection = database['documents']
 
-async def insert_document(doc: dict):
-    return await collection.insert_one(doc)
+class DocumentRepository:
 
-async def get_all_documents():
-    cursor = collection.find()
-    return await cursor.to_list(length=None)
+    def __init__(self):
+        self.collection = document_collection
+
+
+    async def insert_document(self, doc: Document):
+        return await self.collection.insert_one(doc.model_dump())
+
+
+    async def get_all_documents(self):
+        cursor = self.collection.find()
+        return await cursor.to_list(length=None)

--- a/app/routers/document_router.py
+++ b/app/routers/document_router.py
@@ -1,63 +1,13 @@
 from fastapi import APIRouter, UploadFile, File, HTTPException
-from app.services.ocr_service import process_pdf_ocr
-from pdf2image.exceptions import PDFInfoNotInstalledError
-from PIL import UnidentifiedImageError
-from app.repository.document_repository import *
+
+from app.core.response import CommonResponse
+from app.services.document_service import DocumentService
 
 router = APIRouter()
+document_service = DocumentService()
 
-@router.post("/documents/ocr")
-async def convert_to_text(file: UploadFile = File(...)):
-    try:
-        if not file.filename.endswith(".pdf"):
-            raise HTTPException(status_code=400, detail="Only PDF files are supported.")
+@router.post("/school-records/upload")
+async def upload_document(file: UploadFile = File(...)):
+    document_response = await document_service.process_document(file)
 
-        content = await file.read()
-        result = await process_pdf_ocr(content)
-
-        # text만 모아서 하나의 문자열로 만들기
-        # combined_text = ''.join(item['text'] for item in result)
-
-        combined_text = ''
-        combined_grades = {}
-        combined_features = ''
-        for item in result:
-            combined_text += item['text']
-
-            for subject, ranks in item.get('grades', {}).items():
-                if subject not in combined_grades:
-                    combined_grades[subject] = []
-                combined_grades[subject].extend(ranks)
-
-            if item.get('features'):
-                combined_features += item['features']
-
-        await insert_document({"content": combined_text, "grades": combined_grades, "features": combined_features})
-
-        return HTTPException(status_code=200, detail="ocr success")
-
-    except PDFInfoNotInstalledError:
-        raise HTTPException(status_code=500, detail="Poppler is not installed or not found in PATH.")
-
-    except UnidentifiedImageError:
-        raise HTTPException(status_code=422, detail="Failed to process image from PDF.")
-
-    except HTTPException as e:
-        raise e
-
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal Server Error: {str(e)}")
-
-@router.get("/documents/ocr")
-async def test_get_document():
-    try:
-        documents = await get_all_documents()
-
-        # _id가 ObjectId 타입이면 문자열로 변환
-        for doc in documents:
-            if '_id' in doc:
-                doc['_id'] = str(doc['_id'])
-
-        return documents
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Internal Server Error: {str(e)}")
+    return CommonResponse.success_response("생활기록부 업로드 성공", document_response)

--- a/app/schemas/response/document_response.py
+++ b/app/schemas/response/document_response.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+from pydantic.alias_generators import to_camel
+
+
+# 생활기록부 분석 내용 응답
+class DocumentResponse(BaseModel):
+    grades: dict
+    type: str
+    hashtags: list[str]
+    explanation: str

--- a/app/services/document_service.py
+++ b/app/services/document_service.py
@@ -1,0 +1,70 @@
+from app.core.exceptions.base import AppException
+from app.schemas.response.document_response import DocumentResponse
+from app.services.ocr_service import OCRService
+from app.services.gpt_service import GPTService
+from app.models.document_model import Document
+from pdf2image.exceptions import PDFInfoNotInstalledError
+from PIL import UnidentifiedImageError
+from app.repository.document_repository import DocumentRepository
+
+class DocumentService:
+
+    def __init__(self):
+        self.document_repository = DocumentRepository()
+        self.gpt_service = GPTService()
+        self.ocr_service = OCRService()
+
+    async def process_document(self, document):
+        try:
+            if not document.filename.endswith(".pdf"):
+                raise AppException(status_code=400, message="Only PDF files are supported.")
+
+            content = await document.read()
+            result = await self.ocr_service.process_pdf_ocr(content)
+
+            combined_text = ''
+            combined_grades = {}
+            combined_features = ''
+            for item in result:
+                combined_text += item['text']
+
+                for subject, ranks in item.get('grades', {}).items():
+                    if subject not in combined_grades:
+                        combined_grades[subject] = []
+                    combined_grades[subject].extend(ranks)
+
+                if item.get('features'):
+                    combined_features += item['features']
+
+            gpt_result = self.gpt_service.analyze_student_record_structured(combined_features)
+
+
+            document = Document(
+                content=combined_text,
+                grades=combined_grades,
+                features=combined_features,
+                type=gpt_result.get("type"),
+                hashtags=gpt_result.get("hashtags"),
+                explanation=gpt_result.get("explanation")
+            )
+
+            await self.document_repository.insert_document(document)
+
+            return DocumentResponse(
+                grades=combined_grades,
+                type=gpt_result.get("type"),
+                hashtags=gpt_result.get("hashtags"),
+                explanation=gpt_result.get("explanation")
+            )
+
+        except PDFInfoNotInstalledError:
+            raise AppException(status_code=500, message="Poppler is not installed or not found in PATH.")
+
+        except UnidentifiedImageError:
+            raise AppException(status_code=422, message="Failed to process image from PDF.")
+
+        except AppException as e:
+            raise e
+
+        except Exception as e:
+            raise AppException(status_code=500, message=f"Internal Server Error: {str(e)}")

--- a/app/services/gpt_service.py
+++ b/app/services/gpt_service.py
@@ -1,0 +1,52 @@
+import openai
+import json
+from app.core.config import settings
+from app.core.exceptions.base import AppException
+
+
+class GPTService:
+    api_key = settings.GPT_API_KEY
+    client = openai.OpenAI(api_key=api_key)
+
+    def analyze_student_record_structured(self, record_text):
+        prompt = f"""
+        너는 학생 생활기록부를 분석하는 교육 전문가야.
+        다음은 '세부능력 및 특기사항' 항목이야:
+
+        "{record_text}"
+
+
+        이 내용을 바탕으로 다음을 생성해줘:
+        1. 이 학생을 잘 나타낼 수 있는 유형을 써줘(예: 솔선수범하는 학업전공열정 다재다능형)
+        2. 이 학생을 잘 나타낼 수 있는 핵심 키워드를 해시태그 형식으로 5개 출력해줘. (예: #목표지향 #리더형 #솔선수범 #탐구왕성 #진취적 등)
+        3. 1번에서 왜 그 유형인지에 대한 설명 2~3문장 써줘.
+
+
+        이 내용을 바탕으로 다음과 같이 JSON 형식으로 출력해줘:
+
+        {{
+            "type": "",
+            "hashtags": ["#키워드1", "#키워드2", "#키워드3", "#키워드4", "#키워드5"],
+            "explanation" : ""
+        }}
+
+        불필요한 설명 없이 위의 JSON만 응답해.
+            """
+
+        response = self.client.chat.completions.create(
+            model="gpt-4.1-nano",
+            messages=[
+                {"role": "user", "content": prompt}
+            ],
+            temperature=0.7,
+        )
+
+        content = response.choices[0].message.content
+
+        try:
+            return json.loads(content)
+
+        except json.JSONDecodeError:
+            raise AppException(status_code=400, message="세특 분석에 실패했습니다.")
+            # return None
+

--- a/app/services/ocr_service.py
+++ b/app/services/ocr_service.py
@@ -8,182 +8,184 @@ from app.core.config import settings
 import re
 
 
-CLOVA_OCR_URL = settings.CLOVA_OCR_URL
-CLOVA_SECRET_KEY =settings.CLOVA_OCR_SECRET_KEY
-MAX_CONCURRENT_REQUESTS = 5
+class OCRService:
 
-HEADERS = {
-    "X-OCR-SECRET": CLOVA_SECRET_KEY
-}
+    CLOVA_OCR_URL = settings.CLOVA_OCR_URL
+    CLOVA_SECRET_KEY =settings.CLOVA_OCR_SECRET_KEY
+    MAX_CONCURRENT_REQUESTS = 5
+
+    HEADERS = {
+        "X-OCR-SECRET": CLOVA_SECRET_KEY
+    }
 
 
-# 문자열 전처리 함수: 생기부 내용에 필요없는 문자열 삭제
-def clean_text(text):
-    # 앞머리 제거
-    if "학교생활세부사항기록부" in text:
-        pattern1 = rf'^.*?\b\w*학교생활세부사항기록부\(\w*\b\)'
-        text = re.sub(pattern1, '', text, count=1)
+    # 문자열 전처리 함수: 생기부 내용에 필요없는 문자열 삭제
+    def clean_text(self, text):
+        # 앞머리 제거
+        if "학교생활세부사항기록부" in text:
+            pattern1 = rf'^.*?\b\w*학교생활세부사항기록부\(\w*\b\)'
+            text = re.sub(pattern1, '', text, count=1)
 
-    elif "수상명" in text:
-        text = text[text.find("수상명"):]
+        elif "수상명" in text:
+            text = text[text.find("수상명"):]
 
-    elif "체험활동상황" in text:
-        text = text[text.find("체험활동상황") + 20:]
+        elif "체험활동상황" in text:
+            text = text[text.find("체험활동상황") + 20:]
 
-    else:
-        if "정부24" in text:
-            pattern = rf'^.*?\b\w*정부24\S*\b\s+\S+'
         else:
-            pattern = rf'^.*?\b\w*\)'
-        text = re.sub(pattern, '', text, count=1)
-
-    # 꼬리 자르기 (고등학교 이후)
-    matches = list(re.finditer(r'\b\w*고등학교\w*\b', text))
-    if matches:
-        text = text[:matches[-1].start()]
-
-        # 가려진 문구 제거
-        removal_patterns = [
-            r'해당내용.*?않습니다\.',
-            r'해당\s?학년의\s?자료가\s?없습니다',
-            r'해당\s?사항\s?없음'
-        ]
-
-        for pattern in removal_patterns:
-            text = re.sub(pattern, '', text)
-
-    return text.strip()
-
-
-# 성적 추출 메서드
-def extract_grades(text):
-    delete_index = text.find("(수강자수)")
-    if delete_index == -1:
-        return {}
-
-    text = text.replace(" ", "")
-
-    if text.find("<진로선택과목>") != -1:
-        removal_patterns = r'<진로선택과목>.*?이수단위합계'
-        text = re.sub(removal_patterns, '', text)
-
-    text = (text[text.find("(수강자수)") + len("(수강자수)"):].replace("양","").replace("과학과학탐구실험", ""))
-
-    # 과목 패턴 구성
-    subject_mapping = {
-        '기술': 'etc',        # 제2외국어 등
-        '국어': 'korean',
-        '수학': 'math',
-        '영어': 'english',
-        '사회': 'social',
-        '과학': 'science',
-        '한국사': 'history'
-    }
-
-    grade_dict = {}
-    for kor_subject, eng_subject in subject_mapping.items():
-        # 패턴: 과목명 뒤에 성취도(A-F) + 괄호 인원수 + 등수
-        pattern = rf'(?<![가-힣]){re.escape(kor_subject)}.*?[A-F]\(?\d+\)?\s*(\d)'
-        matches = re.findall(pattern, text)
-        if matches:
-            grade_dict[eng_subject] = [int(rank) for rank in matches]
-
-
-    return grade_dict
-
-
-# 세특 추출 메서드
-def extract_features(text):
-    if "세부능력" not in text:
-        return ""
-
-    # 기준 문자열로 나누기
-    parts = text.split("세부능력및특기사항")
-    seoteks = parts[1:]
-
-    result = []
-    for seotek in seoteks:
-        for end_marker in ["<체육", "<진로 선택 과목>", "원점수"]:
-            if end_marker in seotek:
-                seotek = seotek[:seotek.find(end_marker)]
-        result.append(seotek.strip())
-
-    return " ".join(result)
-
-
-# 메인 파이프라인 함수 정의
-def process_document(text):
-    cleaned_text = clean_text(text)
-    grades = extract_grades(cleaned_text)
-    features = extract_features(cleaned_text)
-
-    return {
-        "text": cleaned_text,
-        "grades": grades,
-        "features": features
-    }
-
-
-# ocr
-async def send_ocr_request(img_bytes: bytes, page_number: int):
-    request_json = {
-        "version": "V2",
-        "requestId": str(uuid.uuid4()),
-        "timestamp": int(time.time() * 1000),
-        "images": [{
-            "format": "jpg",
-            "name": f"page_{page_number}"
-        }]
-    }
-
-    files = {
-        'file': (f"page_{page_number}.jpg", img_bytes, 'image/jpeg')
-    }
-
-    data = {
-        'message': str(request_json).replace("'", '"')
-    }
-
-    async with httpx.AsyncClient(timeout=60.0) as client:
-        try:
-            response = await client.post(CLOVA_OCR_URL, headers=HEADERS, files=files, data=data)
-            if response.status_code == 200:
-                ocr_json = response.json()
-                fields = ocr_json["images"][0].get("fields", [])
-                texts = [field["inferText"] for field in fields]
-                full_text = " ".join(texts)
-
-
-                result = process_document(full_text)
-
-                return result
+            if "정부24" in text:
+                pattern = rf'^.*?\b\w*정부24\S*\b\s+\S+'
             else:
-                print("page:", page_number, f"    {response.status_code} - {response.text}")
+                pattern = rf'^.*?\b\w*\)'
+            text = re.sub(pattern, '', text, count=1)
+
+        # 꼬리 자르기 (고등학교 이후)
+        matches = list(re.finditer(r'\b\w*고등학교\w*\b', text))
+        if matches:
+            text = text[:matches[-1].start()]
+
+            # 가려진 문구 제거
+            removal_patterns = [
+                r'해당내용.*?않습니다\.',
+                r'해당\s?학년의\s?자료가\s?없습니다',
+                r'해당\s?사항\s?없음'
+            ]
+
+            for pattern in removal_patterns:
+                text = re.sub(pattern, '', text)
+
+        return text.strip()
+
+
+    # 성적 추출 메서드
+    def extract_grades(self, text):
+        delete_index = text.find("(수강자수)")
+        if delete_index == -1:
+            return {}
+
+        text = text.replace(" ", "")
+
+        if text.find("<진로선택과목>") != -1:
+            removal_patterns = r'<진로선택과목>.*?이수단위합계'
+            text = re.sub(removal_patterns, '', text)
+
+        text = (text[text.find("(수강자수)") + len("(수강자수)"):].replace("양","").replace("과학과학탐구실험", ""))
+
+        # 과목 패턴 구성
+        subject_mapping = {
+            '기술': 'etc',        # 제2외국어 등
+            '국어': 'korean',
+            '수학': 'math',
+            '영어': 'english',
+            '사회': 'social',
+            '과학': 'science',
+            '한국사': 'history'
+        }
+
+        grade_dict = {}
+        for kor_subject, eng_subject in subject_mapping.items():
+            # 패턴: 과목명 뒤에 성취도(A-F) + 괄호 인원수 + 등수
+            pattern = rf'(?<![가-힣]){re.escape(kor_subject)}.*?[A-F]\(?\d+\)?\s*(\d)'
+            matches = re.findall(pattern, text)
+            if matches:
+                grade_dict[eng_subject] = [int(rank) for rank in matches]
+
+
+        return grade_dict
+
+
+    # 세특 추출 메서드
+    def extract_features(self, text):
+        if "세부능력" not in text:
+            return ""
+
+        # 기준 문자열로 나누기
+        parts = text.split("세부능력및특기사항")
+        seoteks = parts[1:]
+
+        result = []
+        for seotek in seoteks:
+            for end_marker in ["<체육", "<진로 선택 과목>", "원점수"]:
+                if end_marker in seotek:
+                    seotek = seotek[:seotek.find(end_marker)]
+            result.append(seotek.strip())
+
+        return " ".join(result)
+
+
+    # 메인 파이프라인 함수 정의
+    def process_document(self, text):
+        cleaned_text = self.clean_text(text)
+        grades = self.extract_grades(cleaned_text)
+        features = self.extract_features(cleaned_text)
+
+        return {
+            "text": cleaned_text,
+            "grades": grades,
+            "features": features
+        }
+
+
+    # ocr
+    async def send_ocr_request(self, img_bytes: bytes, page_number: int):
+        request_json = {
+            "version": "V2",
+            "requestId": str(uuid.uuid4()),
+            "timestamp": int(time.time() * 1000),
+            "images": [{
+                "format": "jpg",
+                "name": f"page_{page_number}"
+            }]
+        }
+
+        files = {
+            'file': (f"page_{page_number}.jpg", img_bytes, 'image/jpeg')
+        }
+
+        data = {
+            'message': str(request_json).replace("'", '"')
+        }
+
+        async with httpx.AsyncClient(timeout=60.0) as client:
+            try:
+                response = await client.post(self.CLOVA_OCR_URL, headers=self.HEADERS, files=files, data=data)
+                if response.status_code == 200:
+                    ocr_json = response.json()
+                    fields = ocr_json["images"][0].get("fields", [])
+                    texts = [field["inferText"] for field in fields]
+                    full_text = " ".join(texts)
+
+
+                    result = self.process_document(full_text)
+
+                    return result
+                else:
+                    print("page:", page_number, f"    {response.status_code} - {response.text}")
+                    return {
+                        "page": page_number,
+                        "text": f"Error: {response.status_code} - {response.text}"
+                    }
+            except Exception as e:
+                print("page:", page_number, "    errormessage: ", str(e))
                 return {
                     "page": page_number,
-                    "text": f"Error: {response.status_code} - {response.text}"
+                    "text": f"Exception: {str(e)}"
                 }
-        except Exception as e:
-            print("page:", page_number, "    errormessage: ", str(e))
-            return {
-                "page": page_number,
-                "text": f"Exception: {str(e)}"
-            }
 
-# ocr 전송: 마지막 페이지 제외
-async def process_pdf_ocr(pdf_bytes: bytes):
-    images = convert_from_bytes(pdf_bytes, dpi=300)
-    results = []
+    # ocr 전송: 마지막 페이지 제외
+    async def process_pdf_ocr(self, pdf_bytes: bytes):
+        images = convert_from_bytes(pdf_bytes, dpi=300)
+        results = []
 
-    for i in range(0, len(images), MAX_CONCURRENT_REQUESTS):
-        tasks = []
-        for j, img in enumerate(images[i:i + MAX_CONCURRENT_REQUESTS]):
-            img_byte_arr = BytesIO()
-            img.save(img_byte_arr, format='JPEG')
-            img_byte_arr.seek(0)
-            tasks.append(send_ocr_request(img_byte_arr.getvalue(), i + j + 1))
+        for i in range(0, len(images), self.MAX_CONCURRENT_REQUESTS):
+            tasks = []
+            for j, img in enumerate(images[i:i + self.MAX_CONCURRENT_REQUESTS]):
+                img_byte_arr = BytesIO()
+                img.save(img_byte_arr, format='JPEG')
+                img_byte_arr.seek(0)
+                tasks.append(self.send_ocr_request(img_byte_arr.getvalue(), i + j + 1))
 
-        batch_result = await asyncio.gather(*tasks)
-        results.extend(batch_result)
+            batch_result = await asyncio.gather(*tasks)
+            results.extend(batch_result)
 
-    return results
+        return results


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 생활기록부 저장시 gpt api를 이용해 세특 내용으로 사용자의 유형, 해시태그와 그 유형의 설명까지 만들어 함께 저장
- 전체적인 생활기록부 저장 코드 리팩토링

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 없음

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #68 


<img width="868" alt="스크린샷 2025-05-27 오전 12 52 34" src="https://github.com/user-attachments/assets/837114b6-b685-4496-9adf-153ebf6d5fb6" />

<img width="1391" alt="스크린샷 2025-05-27 오전 12 52 08" src="https://github.com/user-attachments/assets/c207f51e-8eec-4b57-9108-59d567825099" />
