### PR TITLE
[FEAT] 페르소나별 질문생성 API 추가

### DIFF
--- a/app/repository/persona_repository.py
+++ b/app/repository/persona_repository.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from motor.motor_asyncio import AsyncIOMotorClient
+
+# 로컬 테스트용
+client = AsyncIOMotorClient("mongodb://localhost:27017")
+db = client["interview_db"]
+
+# 질문 저장
+async def save_questions_to_mongo(persona: str, major: str, questions: list):
+    docs = [{
+        "persona": persona,
+        "major": major,
+        "question": q,
+        "created_at": datetime.utcnow()
+    } for q in questions]
+
+    result = await db["questions"].insert_many(docs)
+    return [str(_id) for _id in result.inserted_ids]
+
+# 피드백 저장
+async def save_feedback_to_mongo(
+    question_id: str,
+    answer_id: str,
+    major: str,
+    feedback_text: str
+) -> str:
+    doc = {
+        "question_id": question_id,
+        "answer_id": answer_id,
+        "major": major,
+        "feedback_text": feedback_text,
+        "created_at": datetime.utcnow()
+    }
+    result = await db["feedbacks"].insert_one(doc)
+    return str(result.inserted_id)

--- a/app/routers/persona_question_router.py
+++ b/app/routers/persona_question_router.py
@@ -1,0 +1,48 @@
+from fastapi import APIRouter, UploadFile, File, Form, HTTPException
+from app.services.ocr_service import process_pdf_ocr
+from app.services.persona_question_service import generate_interview_questions
+from app.services.pdf_service import PDFService
+from app.repository.mongo_repository import save_questions_to_mongo
+
+router = APIRouter()
+
+
+@router.post("/interview/persona/question")
+async def generate_questions_from_pdf(
+        file: UploadFile = File(...),
+        persona_label: str = Form(...),
+        major: str = Form(...)
+):
+    try:
+        # 파일 읽기
+        content = await file.read()
+
+        # S3 업로드
+        s3_url = await PDFService.upload_to_s3(content, file.filename)
+
+        # OCR 처리
+        ocr_result = await process_pdf_ocr(content)
+        document_text = "\n".join(item["text"] for item in ocr_result if item.get("text", "").strip())
+
+        if not document_text.strip():
+            raise HTTPException(status_code=400, detail="문서에서 텍스트를 추출할 수 없습니다.")
+
+        # 질문 생성
+        questions = await generate_interview_questions(document_text, persona_label, major)
+
+        # (추가) MongoDB 저장
+        question_ids = await save_questions_to_mongo(
+            persona=persona_label,
+            major=major,
+            questions=questions
+        )
+
+        return {
+            "persona_label": persona_label,
+            "major": major,
+            "questions": questions
+        }
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+

--- a/app/services/pdf_service.py
+++ b/app/services/pdf_service.py
@@ -1,0 +1,26 @@
+import os
+import boto3
+from app.core.config import settings
+
+
+class PDFService:
+    client_s3 = boto3.client(
+        's3',
+        aws_access_key_id=settings.AWS_ACCESS_KEY,
+        aws_secret_access_key=settings.AWS_SECRET_KEY
+    )
+
+    @staticmethod
+    async def upload_to_s3(file_data: bytes, filename: str) -> str:
+        s3_key = f"persona/pdfs/{filename}"
+        bucket_name = settings.S3_BUCKET_NAME
+
+        PDFService.client_s3.put_object(
+            Bucket=bucket_name,
+            Key=s3_key,
+            Body=file_data,
+            ContentType="application/pdf"
+        )
+
+        url = f"https://{bucket_name}.s3.{settings.AWS_REGION}.amazonaws.com/{s3_key}"
+        return url

--- a/app/services/persona_question_service.py
+++ b/app/services/persona_question_service.py
@@ -1,0 +1,36 @@
+import openai
+import os
+
+client = openai.OpenAI(api_key=os.getenv("GPT_API_SECRET_KEY"))
+
+async def generate_interview_questions(document_text: str, persona_label: str, major: str) -> str:
+    prompt = f"""
+당신은 다음과 같은 성향의 대학 면접관입니다:
+
+{persona_label}
+
+아래는 한 수험생의 자기소개서 또는 생활기록부입니다.
+
+아래 형식에 따라 총 10개의 질문을 생성하세요.  
+질문은 지원 전공 '{major}'과 문서 내용을 기반으로 하며, 면접관의 성격도 반영되어야 합니다.
+
+[질문 구성]
+1. 자기소개를 요청하는 질문  
+2. 학교(대학) 지원 동기를 묻는 질문  
+3. 전공(학과) 지원 동기를 묻는 질문  
+4. 본인의 장단점을 묻는 질문  
+5~9. 아래 문서를 참고하여 학생의 경험, 가치관, 활동, 전공 관련성 등을 기반으로 위 면접관 스타일에 맞춘 심화 질문 5개 생성  
+10. 마지막 한마디 혹은 마무리 발언을 요청하는 질문
+
+[문서 내용]
+{document_text}
+    """
+
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.7
+    )
+
+    return response.choices[0].message.content.strip()
+


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 페르소나별 질문생성 API 구현
- 1-4번 공통질문, 4-9 페르소나별 질문, 10 공통질문(마지막할말) 구조로 프롬프트 완료
- s3 pdf 저장로직 및 mongo db 저장로직 추가

## 📌 PR Point
<img width="819" alt="personal" src="https://github.com/user-attachments/assets/f9f9ba6e-f497-4d0a-a419-4ca585eec775" />


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #67 
