### PR TITLE
[FEAT] 답변기반 꼬리질문 API 추가

### DIFF
--- a/app/routers/interview_router.py
+++ b/app/routers/interview_router.py
@@ -1,14 +1,15 @@
 from typing import Annotated
-
-from fastapi import APIRouter, UploadFile, File, Form, Path, Depends
-
+from fastapi import APIRouter, UploadFile, File, Form, Path, Depends, HTTPException
 from app.core.response import CommonResponse
 from app.models.user_model import User
 from app.schemas.request.create_combine_request import CreateCombineRequest
+from app.schemas.response.followup_question_response import FollowupQuestionResponse
 from app.services.answer_service import AnswerService
 from app.services.auth_service import AuthService
 from app.services.combine_service import CombineService
 from app.services.interview_service import InterviewService
+from app.services.followup_question_service import FollowupQuestionService
+from app.core.exceptions.custom import InterviewNotFoundException
 
 auth_service = AuthService()
 router = APIRouter(dependencies=[Depends(auth_service.get_current_user)])
@@ -42,3 +43,31 @@ async def analysis_video(
     result = await AnswerService.analysis_answer_video(file, interview_id, question_id)
 
     return CommonResponse.success_response("영상 분석 성공", result)
+
+@router.post("/interview/answer/{answer_id}/followup-questions", response_model=FollowupQuestionResponse)
+async def generate_followup_questions(
+    answer_id: str = Path(..., description="답변 ID")
+):
+    """
+    답변 기반 꼬리 질문 생성 API
+
+    Args:
+        answer_id (str): 답변 ID (path parameter)
+
+    Returns:
+        FollowupQuestionResponse: 생성된 꼬리 질문들
+            - answerId (str): 답변 ID
+            - originalAnswer (str): 원본 답변 내용
+            - followupQuestions (list): 생성된 꼬리 질문 목록
+
+    Raises:
+        HTTPException:
+            - 404: 답변을 찾을 수 없음
+            - 500: 꼬리 질문 생성 중 오류 발생
+    """
+    try:
+        return await FollowupQuestionService.generate_followup_questions(answer_id)
+    except InterviewNotFoundException as e:
+        raise HTTPException(status_code=404, detail=str(e))
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"꼬리 질문 생성 중 오류가 발생했습니다: {str(e)}")

--- a/app/schemas/response/followup_question_response.py
+++ b/app/schemas/response/followup_question_response.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+from typing import List
+
+class FollowupQuestionResponse(BaseModel):
+    answerId: str
+    originalAnswer: str
+    followupQuestions: List[str] 

--- a/app/services/followup_question_service.py
+++ b/app/services/followup_question_service.py
@@ -1,0 +1,75 @@
+import openai
+from typing import List
+from bson import ObjectId
+from app.core.config import settings
+from app.core.database import get_mongo_client
+from app.schemas.response.followup_question_response import FollowupQuestionResponse
+from app.core.exceptions.custom import InterviewNotFoundException
+
+
+client = openai.OpenAI(api_key=settings.GPT_API_KEY)
+db = get_mongo_client()
+class FollowupQuestionService:
+    @staticmethod
+    async def generate_followup_questions(answer_id: str) -> FollowupQuestionResponse:
+        """
+        답변 기반으로 꼬리 질문 생성.
+        
+        Args:
+            answer_id (str): 답변 ID
+            
+        Returns:
+            FollowupQuestionResponse: 생성된 꼬리 질문들
+            
+        Raises:
+            InterviewNotFoundException: 답변을 찾을 수 없는 경우
+        """
+        # 답변 조회
+        answer_doc = await db["answers"].find_one({"_id": ObjectId(answer_id)})
+        if not answer_doc:
+            raise InterviewNotFoundException("답변을 찾을 수 없습니다.")
+        
+        answer_text = answer_doc["answer"]
+        question_id = answer_doc.get("question_id")
+        
+        # 원본 질문도 함께 조회 (컨텍스트를 위해)
+        original_question = ""
+        if question_id:
+            question_doc = await db["questions"].find_one({"_id": ObjectId(question_id)})
+            if question_doc:
+                original_question = question_doc["question"]
+        
+        # 꼬리 질문 생성
+        followup_prompt = f"""
+다음은 면접에서 나온 질문과 지원자의 답변입니다. 이 답변을 바탕으로 더 깊이 있게 탐구할 수 있는 꼬리 질문 1개를 생성해주세요.
+
+[원본 질문]
+{original_question}
+
+[지원자 답변]
+{answer_text}
+
+꼬리 질문은 다음 기준을 고려하여 한 문장으로 작성해주세요:
+- 답변 내용을 더 구체적으로 설명하도록 유도
+- 답변에서 언급된 경험이나 배경을 심화 탐구
+- 자연스럽고 대화형 면접 상황에 적합
+
+반드시 1개의 문장만 출력하고, 다른 설명이나 줄바꿈 없이 질문만 출력해주세요.
+"""
+        
+        response = client.chat.completions.create(
+            model="gpt-4o",
+            messages=[{"role": "user", "content": followup_prompt}],
+            temperature=0.7
+        )
+        
+        # 응답을 파싱하여 질문 목록으로 변환
+        followup_text = response.choices[0].message.content.strip()
+        followup_questions = [q.strip() for q in followup_text.split('\n') if q.strip()]
+        
+        # 결과 반환
+        return FollowupQuestionResponse(
+            answerId=answer_id,
+            originalAnswer=answer_text,
+            followupQuestions=followup_questions
+        ) 

--- a/app/services/persona_question_service.py
+++ b/app/services/persona_question_service.py
@@ -16,7 +16,6 @@ class PersonaQuestionService:
             - questionIndex (int): 질문 순서
             - questionText (str): 메인 질문 내용
             - hasFollowUp (bool): 후속 질문 존재 여부
-            - followUpText (str): 후속 질문 내용 (hasFollowUp이 true인 경우)
 
     Example:
         [
@@ -24,13 +23,11 @@ class PersonaQuestionService:
                 "questionIndex": 4,
                 "questionText": "당신의 가장 큰 장점은 무엇인가요?",
                 "hasFollowUp": true,
-                "followUpText": "이 장점을 발휘한 구체적인 사례를 말씀해주세요."
             },
             {
                 "questionIndex": 5,
                 "questionText": "당신의 단점은 무엇인가요?",
                 "hasFollowUp": true,
-                "followUpText": "이 단점을 극복하기 위해 어떤 노력을 하고 있나요?"
             }
         ]
     """
@@ -75,24 +72,6 @@ class PersonaQuestionService:
 
         for idx, text in enumerate(question_lines):
             index = idx + 1
-            has_followup = index in [4, 5, 6, 7, 8, 9]
-            followup_question: Optional[str] = None
-
-            # 4~9번 질문에 대해서 꼬리 응답 생성
-            if has_followup:
-                followup_prompt = f"""
-당신은 '{persona_label}' 성향의 대학 면접관입니다.
-
-다음 질문에 대해 수험자의 사고를 확장시킬 수 있는 꼬리질문 1개를 생성하세요.
-[질문]
-{text}
-"""
-                followup_response = client.chat.completions.create(
-                    model="gpt-4o-mini",
-                    messages=[{"role": "user", "content": followup_prompt}],
-                    temperature=0.7
-                )
-                followup_question = followup_response.choices[0].message.content.strip()
 
             questions.append(QuestionOutput(
                 interviewId=interview_id,
@@ -101,8 +80,6 @@ class PersonaQuestionService:
                 totalQuestions=len(question_lines),
                 personaLabel=persona_label,
                 major=major,
-                hasFollowup=has_followup,
-                followupQuestion=followup_question,
                 createdAt=datetime.utcnow(),
                 updatedAt=datetime.utcnow()
             ))


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- interview_router 하단에 답변기반 꼬리질문 생성 API 추가
- 4-9번 질문의 면접자 답변에 대한 꼬리질문 1개씩 생성
- 기존 질문생성 API에서 꼬리질문 부분 프롬프트 삭제

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #139 
