### PR TITLE
[FIX] 질문 생성 버그 수정

### DIFF
--- a/app/models/question_model.py
+++ b/app/models/question_model.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Optional, List
 
 from pydantic import BaseModel
 from datetime import datetime
@@ -11,7 +11,7 @@ class Question(BaseModel):
     question_text: Optional[str] = None
     question_index: Optional[int] = None
     total_questions: Optional[int] = None
-    persona: Optional[str] = None
+    persona: Optional[List[str]] = None
     major: Optional[str] = None
     university: Optional[str] = None # 대학 추가
     created_at: Optional[datetime] = None

--- a/app/repository/combine_repository.py
+++ b/app/repository/combine_repository.py
@@ -1,3 +1,7 @@
+from typing import Optional
+
+from bson import ObjectId
+
 from app.core.database import database
 from app.models.combine_model import Combine
 
@@ -10,3 +14,6 @@ class CombineRepository:
     async def insert(self, combine: Combine) -> str:
         result = await self.collection.insert_one(combine.model_dump())
         return str(result.inserted_id)
+
+    async def find_by_id(self, id: str) -> Combine:
+        return await self.collection.find_one({"_id": ObjectId(id)})

--- a/app/repository/interview_repository.py
+++ b/app/repository/interview_repository.py
@@ -15,7 +15,7 @@ class InterviewRepository:
         result = await self.collection.insert_one(interview.model_dump())
         return str(result.inserted_id)
 
-    async def find_by_id(self, id: str) -> Optional[dict]:
+    async def find_by_id(self, id: str) -> Interview:
         return await self.collection.find_one({"_id": ObjectId(id)})
 
     async def update(self, id: str, update_fields: dict) -> bool:

--- a/app/repository/question_repository.py
+++ b/app/repository/question_repository.py
@@ -13,7 +13,7 @@ class QuestionRepository:
     async def find_by_id(self, id: str) -> Optional[dict]:
         return await self.collection.find_one({"_id": ObjectId(id)})
 
-    async def save_questions(self, persona: str, major: str, university :str, questions: List[str]) -> List[str]:
+    async def save_questions(self, persona: List[str], major: str, university :str, questions: List[str]) -> List[str]:
         docs = [
             Question(
                 persona=persona,

--- a/app/routers/persona_question_router.py
+++ b/app/routers/persona_question_router.py
@@ -1,64 +1,26 @@
-from fastapi import APIRouter, UploadFile, File, Form, HTTPException, Depends
+from pathlib import Path
+
+from fastapi import APIRouter, Depends
+from numba.scripts.generate_lower_listing import description
+
+from app.core.response import CommonResponse
 from app.services.auth_service import AuthService
 from app.services.ocr_service import OCRService
 from app.services.persona_question_service import PersonaQuestionService
-from app.repository.question_repository import QuestionRepository
-from app.services.s3_service import S3Service
 
 auth_service = AuthService()
 router = APIRouter(
     dependencies=[Depends(auth_service.get_current_user)]
 )
 
-question_repo = QuestionRepository()
 ocr_service = OCRService()
 
-@router.post("/interview/persona/question")
+@router.post("/interview/{interview_id}/persona/question")
 async def generate_questions_from_pdf(
-    file: UploadFile = File(...),
-    persona_label: str = Form(...),
-    major: str = Form(...),
-    university: str = Form(...),
-    interview_id: str = Form(...)
+    interview_id: str = Path(description="인터뷰 ID")
 ):
-    try:
-        # 파일 읽기
-        content = await file.read()
+    result = await PersonaQuestionService.createPersonaQuestion(interview_id)
 
-        # S3 업로드
-        s3_url = await S3Service.upload_to_s3(content, file.filename)
-
-        # OCR 처리
-        ocr_result = await ocr_service.process_pdf_ocr(content)
-        document_text = "\n".join(item["text"] for item in ocr_result if item.get("text", "").strip())
-
-        if not document_text.strip():
-            raise HTTPException(status_code=400, detail="문서에서 텍스트를 추출할 수 없습니다.")
-
-        # 질문 + 꼬리질문 생성
-        questions = await PersonaQuestionService.generate_interview_questions(
-            document_text=document_text,
-            persona_label=persona_label,
-            major=major,
-            university=university,
-            interview_id=interview_id
-        )
-
-        # MongoDB에 저장
-        question_ids = await question_repo.save_questions(
-            persona=persona_label,
-            major=major,
-            university=university,
-            questions=questions
-        )
-
-        return {
-            "personaLabel": persona_label,
-            "major": major,
-            "questions": questions
-        }
-
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+    return CommonResponse.success_response("페르소나 기반 질문 생성 성공", result)
 
 

--- a/app/schemas/response/question_response.py
+++ b/app/schemas/response/question_response.py
@@ -1,6 +1,23 @@
 from pydantic import BaseModel
-from typing import Optional
+from typing import Optional, List
+
+from pydantic.alias_generators import to_camel
+
 
 class QuestionOutput(BaseModel):
-    questionIndex: int
-    questionText: str
+    question_index: int
+    question_text: str
+
+    class Config:
+        alias_generator = to_camel
+        allow_population_by_field_name = True
+
+
+class CreatePersonaQuestionResponse(BaseModel):
+    # persona_label: str
+    # department: str
+    questions: List[QuestionOutput]
+
+    class Config:
+        alias_generator = to_camel
+        allow_population_by_field_name = True

--- a/app/services/persona_question_service.py
+++ b/app/services/persona_question_service.py
@@ -1,13 +1,23 @@
 import openai
 from datetime import datetime
-from typing import List, Optional
+from typing import List
 from app.core.config import settings
-from app.models.question_model import Question
-from app.schemas.response.question_response import QuestionOutput
+from app.core.exceptions.base import AppException
+from app.repository.combine_repository import CombineRepository
+from app.repository.document_repository import DocumentRepository
+from app.repository.interview_repository import InterviewRepository
+from app.repository.question_repository import QuestionRepository
+from app.schemas.response.question_response import QuestionOutput, CreatePersonaQuestionResponse
 
 client = openai.OpenAI(api_key=settings.GPT_API_KEY)
 
+
 class PersonaQuestionService:
+    combine_repo = CombineRepository()
+    interview_repo = InterviewRepository()
+    document_repo = DocumentRepository()
+    question_repo = QuestionRepository()
+
     """
     페르소나 기반 질문 목록
 
@@ -31,13 +41,14 @@ class PersonaQuestionService:
             }
         ]
     """
+
     @staticmethod
     async def generate_interview_questions(
-        document_text: str,
-        persona_label: str,
-        major: str,
-        university: str,
-        interview_id: str
+            document_text: str,
+            persona_label: List[str],
+            major: str,
+            university: str,
+            interview_id: str
     ) -> List[QuestionOutput]:
         prompt = f"""
 당신은 다음과 같은 성향의 대학 면접관입니다:
@@ -89,3 +100,38 @@ class PersonaQuestionService:
             ))
 
         return questions
+
+    async def createPersonaQuestion(interview_id: str) -> CreatePersonaQuestionResponse:
+        interview = await PersonaQuestionService.interview_repo.find_by_id(interview_id)
+        if interview is None:
+            raise AppException(status_code=404, message="인터뷰를 찾을 수 없습니다.")
+
+        combine_id = interview["combine_id"]
+        combine = await PersonaQuestionService.combine_repo.find_by_id(combine_id)
+        if combine is None:
+            raise AppException(status_code=404, message="면접 조합을 찾을 수 없습니다.")
+
+        user_id = combine["user_d"]
+        document = await PersonaQuestionService.document_repo.find_by_user_email(user_id)
+
+        questions = await PersonaQuestionService.generate_interview_questions(
+            document_text=document["features"],
+            persona_label=combine["department"],
+            major=combine["department"],
+            university=combine["university"],
+            interview_id=interview_id
+        )
+
+        # MongoDB에 저장
+        await PersonaQuestionService.question_repo.save_questions(
+            persona=combine["persona"],
+            major=combine["department"],
+            university=combine["university"],
+            questions=questions
+        )
+
+        return CreatePersonaQuestionResponse(
+            # personaLabel=combine["persona"],
+            # department=combine["department"],
+            questions=questions
+        )


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 질문 생성 API interview_id만 받도록 수정
- router에 있는 예외처리 코드 service 파일로 이동
- interview_id로 면접 조합 조회 하고 면접 조합 정보로 질문 생성 요청하도록 수정
- 사용자 생활기록부 문서의 텍스트 내용은 사용자 아이디로 문서 조회해 저장된 텍스트 불러오도록 수정

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 사용자 생활기록부 내용중 content와 fearture가 있는데 둘 중 질문 생성시에 사용될 텍스트를 어떤 것을 써야할지

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #145
