### PR TITLE
[FIX] 질문 저장시 인터뷰 아이디, 질문 인덱스 저장

### DIFF
--- a/app/repository/question_repository.py
+++ b/app/repository/question_repository.py
@@ -13,13 +13,16 @@ class QuestionRepository:
     async def find_by_id(self, id: str) -> Optional[dict]:
         return await self.collection.find_one({"_id": ObjectId(id)})
 
-    async def save_questions(self, persona: List[str], major: str, university :str, questions: List[str]) -> List[str]:
+    async def save_questions(self, interview_id: str, persona: List[str], major: str, university :str, questions: List[str]) -> List[str]:
         docs = [
             Question(
+                interview_id=interview_id,
                 persona=persona,
                 major=major,
                 university=university,   #프롬프트 정확성 위해 추가
-                question=q,
+                question_text=q.question_text,
+                question_index=q.question_index,
+                total_questions=len(questions),
                 created_at=datetime.utcnow()
             ).model_dump()
             for q in questions

--- a/app/services/persona_question_service.py
+++ b/app/services/persona_question_service.py
@@ -115,7 +115,7 @@ class PersonaQuestionService:
         document = await PersonaQuestionService.document_repo.find_by_user_email(user_id)
 
         questions = await PersonaQuestionService.generate_interview_questions(
-            document_text=document["features"],
+            document_text=document["question_text"],
             persona_label=combine["department"],
             major=combine["department"],
             university=combine["university"],
@@ -124,6 +124,7 @@ class PersonaQuestionService:
 
         # MongoDB에 저장
         await PersonaQuestionService.question_repo.save_questions(
+            interview_id=interview_id,
             persona=combine["persona"],
             major=combine["department"],
             university=combine["university"],

--- a/app/services/persona_question_service.py
+++ b/app/services/persona_question_service.py
@@ -115,7 +115,7 @@ class PersonaQuestionService:
         document = await PersonaQuestionService.document_repo.find_by_user_email(user_id)
 
         questions = await PersonaQuestionService.generate_interview_questions(
-            document_text=document["question_text"],
+            document_text=document["content"],
             persona_label=combine["department"],
             major=combine["department"],
             university=combine["university"],


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 질문 저장시 인터뷰 아이디, 질문 인덱스 저장
- 생기부에서 추출한 text 중 content로 질문 생성하도록 수정

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 
<img width="1041" alt="스크린샷 2025-06-10 오후 11 14 36" src="https://github.com/user-attachments/assets/8120f7ac-cb2c-4e34-a908-f203c8460193" />


### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #148
