### PR TITLE
[FIX] ocr 리소스 문제 해결

### DIFF
--- a/app/services/ocr_service.py
+++ b/app/services/ocr_service.py
@@ -12,7 +12,7 @@ class OCRService:
 
     CLOVA_OCR_URL = settings.CLOVA_OCR_URL
     CLOVA_SECRET_KEY =settings.CLOVA_OCR_SECRET_KEY
-    MAX_CONCURRENT_REQUESTS = 5
+    MAX_CONCURRENT_REQUESTS = 3
 
     HEADERS = {
         "X-OCR-SECRET": CLOVA_SECRET_KEY
@@ -134,18 +134,26 @@ class OCRService:
 
     # ocr 전송
     async def process_pdf_ocr(self, pdf_bytes: bytes):
-        images = convert_from_bytes(pdf_bytes, dpi=300)
-        results = []
 
-        for i in range(0, len(images), self.MAX_CONCURRENT_REQUESTS):
-            tasks = []
-            for j, img in enumerate(images[i:i + self.MAX_CONCURRENT_REQUESTS]):
+        images = convert_from_bytes(pdf_bytes, dpi=300, use_cropbox=False, strict=False)
+        semaphore = asyncio.Semaphore(self.MAX_CONCURRENT_REQUESTS)
+
+        async def limited_ocr_request(img_bytes, page_number):
+            async with semaphore:
+                return await self.send_ocr_request(img_bytes, page_number)
+
+        tasks = []
+        for idx, img in enumerate(images):
+            img_byte_arr = None
+            try:
                 img_byte_arr = BytesIO()
                 img.save(img_byte_arr, format='JPEG')
                 img_byte_arr.seek(0)
-                tasks.append(self.send_ocr_request(img_byte_arr.getvalue(), i + j + 1))
+                tasks.append(limited_ocr_request(img_byte_arr.getvalue(), idx + 1))
+            finally:
+                img.close()
+                del img
+                img_byte_arr.close()
 
-            batch_result = await asyncio.gather(*tasks)
-            results.extend(batch_result)
-
+        results = await asyncio.gather(*tasks)
         return results


### PR DESCRIPTION
## ⛏ 작업 내용
<!-- 작업한 내용을 간단하게 적어주세요! -->
- 이미지 병렬 처리 갯수 5개 -> 3개로 변경
- 세마포어로 전체 동시 요청 수 제한
- img 처리 직후에 메모리 해제 후 메모리 빨리 회수하도록 del을 통해 유도
<img width="753" alt="스크린샷 2025-06-16 오전 8 48 44" src="https://github.com/user-attachments/assets/b6e47dbb-b7ef-49a8-8f92-8aef6b1ebb4f" />

## 📌 PR Point
<!-- 주의할 사항이나 같이 고민해볼 부분, 리뷰를 원하는 부분 등을 적어주세요! -->
- 내용

### ✅ Issue
<!-- 생성한 관련 이슈가 있다면 Resolved #이슈번호로 닫아주세요! -->
Resolved #156 
